### PR TITLE
use better flag package, incompatible changes

### DIFF
--- a/cmd/pn/main.go
+++ b/cmd/pn/main.go
@@ -129,6 +129,7 @@ func main() {
 	log.SetFlags(0)
 	args := parseFlags()
 
+	// exit program after --help
 	if len(args) == 0 {
 		return
 	}


### PR DESCRIPTION
Switch to better flag package, which provides more unix like semantics.

This also needs some incompatible changes to flag handling:
- piping to stderr/stdout can be disabled via extra long options
  --no-stream-stderr and --no-stream-stdout explicitly. The old
  parameters -e and -o are gone, too and free for future features now.
  
  Rationale: The new flags package cannot only values to booleans,
  mentioned on command line. Boolean parameters accept no options.
  Removing the old parameters helps detecting the change. They also make
  no sense anymore, if they don't have their logic inverted.
- --max-start-delay (-i) and thus the start spreading now disabled by
  default and should be enabled as needed.
  
  Rationale: Defaulting to a magic value is cumbersome and the new flag
  package will display the magic value as default value. So we need 0 as
  default, which means disabling the spreading.

@mlafeldt PTAL
