### PR TITLE
try without newline

### DIFF
--- a/cmd/pn/linewriter.go
+++ b/cmd/pn/linewriter.go
@@ -13,6 +13,13 @@ var lf = []byte("\n")
 
 func (l *LineWriter) Write(p []byte) (n int, err error) {
 	for _, line := range bytes.SplitAfter(p, lf) {
+
+		// drop pure whitespace lines and fake successful write of them
+		if nospaces := bytes.TrimSpace(line); bytes.Equal(nospaces, lf) {
+			n += len(line)
+			continue
+		}
+
 		var written int
 		written, err = l.w.Write(line)
 		n += written


### PR DESCRIPTION
Try logging with no newline to avoid `#012` message content on logfiles.
