### PR TITLE
Fix endless loop in logStream()

### DIFF
--- a/cmd/pn/log.go
+++ b/cmd/pn/log.go
@@ -31,11 +31,7 @@ func logStream(r io.Reader, logger io.Writer, wg *sync.WaitGroup) {
 	wg.Add(1)
 
 	go func() {
-		for {
-			if _, err := io.Copy(logger, r); err != nil {
-				break
-			}
-		}
+		io.Copy(logger, r)
 		wg.Done()
 	}()
 }


### PR DESCRIPTION
For io.Copy, EOF is not an error.
