### PR TITLE
Make sure log streams are done before command returns

### DIFF
--- a/cmd/pn/main.go
+++ b/cmd/pn/main.go
@@ -211,6 +211,8 @@ func main() {
 		return
 	}
 
+	wg.Wait()
+
 	if err := cmd.Wait(); err != nil {
 		timer.Stop()
 		Failed(err)
@@ -218,6 +220,4 @@ func main() {
 		timer.Stop()
 		Ok()
 	}
-
-	wg.Wait()
 }


### PR DESCRIPTION
... thereby trying to fix the problem that periodicnoise sometimes does not kill a process after timeout.
