### PR TITLE
distinguish between transient and permanent errors

### DIFF
--- a/cmd/pn/log.go
+++ b/cmd/pn/log.go
@@ -40,11 +40,7 @@ func canContinue(expire time.Time, had_progress bool, err error) bool {
 			// If we could never connect, we cannot decide, whether this is a temporary failure,
 			// or the address we connect to is simply wrong.
 			switch errno {
-			case syscall.ECONNREFUSED:
-				fallthrough
-			case syscall.ENETUNREACH:
-				fallthrough
-			case syscall.EHOSTUNREACH:
+			case syscall.ECONNREFUSED, syscall.ENETUNREACH, syscall.EHOSTUNREACH:
 				return true
 			}
 		}


### PR DESCRIPTION
In order to only retry on temporary problems, but fail on permanent
problems, let's build some logic to distinguish these.

We have 3 clear cases
1. We are beyond our time budget -> fail immediately
2. The remote is not reachable -> retry, if we could ever connect,
   fail otherwise
3. The net package classifies this as Temporary condition or Timeout ->
   retry

All other cases are considered permanent failures.

@mlafeldt PTAL

Reason I added this, is that I have seen endless retries on a bad file descriptor in the new code. I also not felt very good with endless retries.
