### PR TITLE
Fix annoying report bug

### DIFF
--- a/cmd/pn/main.go
+++ b/cmd/pn/main.go
@@ -49,7 +49,7 @@ func Busy() {
 func Failed(err error) {
 	var message string
 	code, s := error2exit(err)
-	log.Println("FATAL:", s)
+	log.Printf("INFO: %s (considered %s for monitoring)\n", s, code)
 	if firstbytes == nil {
 		message = s
 	} else {


### PR DESCRIPTION
Since we remap funny exit codes to nagios standard exist codes now,
consider the exit code as information only and clear up what it means
for monitoring.

This avoids confusing users.

fixes #39 
