### PR TITLE
More flexible monitoring sender/receiver

### DIFF
--- a/cmd/pn/flags.go
+++ b/cmd/pn/flags.go
@@ -22,6 +22,8 @@ var opts struct {
 	MonitorWarning   []uint8       `long:"monitor-warning" description:"add exit code to warn about"`
 	MonitorCritical  []uint8       `long:"monitor-critical" description:"add exit code to consider as critical failure"`
 	MonitorUnknown   []uint8       `long:"monitor-unknown" description:"add exit code to consider as state not known"`
+	SendAs           string        `long:"send-as" description:"send monitoring events masquerading as this entity"`
+	SendTo           string        `long:"send-to" description:"send monitoring events to this service"`
 }
 
 // FlagConstraintError happens when command line arguments make no sense or contradict each other

--- a/cmd/pn/monitor.go
+++ b/cmd/pn/monitor.go
@@ -107,6 +107,8 @@ func monitor(state monitoringResult, message string) {
 	}
 
 	call = strings.Replace(call, "%(event)", shellEscape(monitoringEvent), -1)
+	call = strings.Replace(call, "%(send_to)", shellEscape(opts.SendTo), -1)
+	call = strings.Replace(call, "%(send_as)", shellEscape(opts.SendAs), -1)
 	call = strings.Replace(call, "%(state)", state.String(), -1)
 	call = strings.Replace(call, "%(message)", shellEscape(message), -1)
 	// do argument interpolation


### PR DESCRIPTION
In order to support sending events as multiple entities per host
and in order to send to specific monitoring servers for specific
entities/events.

There is neither a default for send-as not for send-to. If you want it
static, then don't use these options and hard-code the senders and/or
receivers into the config.

The options `--send-as` and `--send-to` are free form strings.
They can even be URLs and contain spaces if your monitoring solution
works this way.

closes Github Issue #38 

@Luzifer or @mlafeldt PTAL
